### PR TITLE
Fix and enhance branding by renaming eventyay-video

### DIFF
--- a/webapp/src/views/admin/config/schedule.vue
+++ b/webapp/src/views/admin/config/schedule.vue
@@ -174,7 +174,7 @@ export default {
 			this.error = error
 			console.log(error)
 		}
-		this.$watch(() => this.config?.pretalx?.domain ? `${this.pretalxDomain}${this.config.pretalx.event}/p/venueless/check` : null, async (url) => {
+		this.$watch(() => this.config?.pretalx?.domain ? `${this.pretalxDomain}${this.config.pretalx.event}/p/eventyay-video/check` : null, async (url) => {
 			this.isPretalxPluginInstalled = false
 			console.log(url)
 			if (!url || !/^https?:\/\//.test(url)) return
@@ -204,7 +204,7 @@ export default {
 				long: true
 			})
 			const apiUrl = config.api.base.startsWith('http') ? config.api.base : (window.location.origin + config.api.base)
-			window.location = `${this.pretalxDomain}orga/event/${this.config.pretalx.event}/settings/p/venueless/?url=${apiUrl}&token=${token}&returnUrl=${window.location.href}`
+			window.location = `${this.pretalxDomain}orga/event/${this.config.pretalx.event}/settings/p/eventyay-video/?url=${apiUrl}&token=${token}&returnUrl=${window.location.href}`
 		},
 		async save () {
 			this.$v.$touch()


### PR DESCRIPTION
Due to the renaming of the Eventyay-Talk-Video plugin, it is necessary to update the configuration and branding within the Eventyay Video repository.

For reference, please see the related pull request on the Eventyay-Talk-Video repository: [Eventyay-Talk-Video PR #2](https://github.com/fossasia/eventyay-talk-video/pull/2).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the branding and configuration references in the admin schedule view to reflect the renaming of the Eventyay-Talk-Video plugin to Eventyay-Video.

- **Enhancements**:
    - Updated the branding and configuration references from 'venueless' to 'eventyay-video' in the admin schedule view.

<!-- Generated by sourcery-ai[bot]: end summary -->