### PR TITLE
Fix Add visual of how many people are watching in each room

### DIFF
--- a/webapp/src/components/RoomsSidebar.vue
+++ b/webapp/src/components/RoomsSidebar.vue
@@ -26,6 +26,10 @@ transition(name="sidebar")
 					template(v-else)
 						.room-icon(aria-hidden="true")
 						.name(v-html="$emojify(stage.room.name)")
+						.buffer
+						template(v-if="stage.room.users")
+							i.mdi.mdi-account-group.icon-viewer
+							.name(v-html="stage.room.users")
 						.notifications(v-if="stage.notifications") {{ stage.notifications }}
 			.group-title#chats-title(v-if="roomsByType.videoChat.length || roomsByType.textChat.length || hasPermission('world:rooms.create.chat') || hasPermission('world:rooms.create.bbb')")
 				span {{ $t('RoomsSidebar:channels-headline:text') }}
@@ -308,7 +312,7 @@ export default {
 			&.router-link-exact-active, &.active
 				.room-icon::before
 					color: var(--clr-sidebar-text-secondary)
-			.room-icon
+			.room-icon, .icon-viewer
 				width: 22px
 				&::before
 					font-family: "Material Design Icons"
@@ -318,6 +322,9 @@ export default {
 					margin: 0 auto
 					display: block
 					width: 20px
+			.icon-viewer
+				&::before
+					line-height: 32px
 
 			&.starts-with-emoji
 				padding: 0 18px


### PR DESCRIPTION
Re-add visual indicators for the number of viewers in each room.

This commit restores the feature that displays the number of people currently watching in each room. This functionality was accidentally removed in a previous commit and is crucial for providing real-time information about viewer engagement.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request reintroduces the feature that displays the number of people currently watching in each room, providing real-time information about viewer engagement.

- **Bug Fixes**:
    - Restored the visual indicators for the number of viewers in each room, which were accidentally removed in a previous commit.

<!-- Generated by sourcery-ai[bot]: end summary -->