### PR TITLE
Fix theme loading error by ensuring default colors are used if theme colors are undefined

### DIFF
--- a/webapp/src/theme.js
+++ b/webapp/src/theme.js
@@ -61,7 +61,7 @@ const DEFAULT_IDENTICONS = {
 	style: 'identiheart'
 }
 
-const configColors = config.theme?.colors
+const configColors = config.theme?.colors || DEFAULT_COLORS
 
 const themeConfig = {
 	colors: configColors,


### PR DESCRIPTION
This PR fixes the [Error on loading theme configuration](https://github.com/fossasia/eventyay-video/issues/172). It ensures configColors is always assigned a valid value. If theme colors are defined, they are used; otherwise, default colors are applied, preventing errors when configColors is not defined. Below is an image demonstrating the working sidebar with the color theme.
![Screenshot from 2024-07-25 13-15-51](https://github.com/user-attachments/assets/7590564f-0271-458e-ad69-1db4873b9ab0)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue where the application would error out if theme colors were not defined in the configuration. The fix ensures that default colors are applied in such cases, preventing the error and ensuring consistent theme loading.

- **Bug Fixes**:
    - Fixed theme loading error by ensuring default colors are used if theme colors are undefined.

<!-- Generated by sourcery-ai[bot]: end summary -->