### PR TITLE
fix-140: Add Z-Index to Scrollbar Rail Wrappers

### DIFF
--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -107,4 +107,7 @@ export default {
 			text-align: center
 	.c-grid-schedule .grid > .room
 		top: 0
+	.scroll-parent
+		.bunt-scrollbar-rail-wrapper-x, .bunt-scrollbar-rail-wrapper-y
+			z-index: 30
 </style>


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug by adding a z-index to the scrollbar rail wrappers in the schedule view to ensure they are displayed correctly in the stacking order.

- **Bug Fixes**:
    - Added z-index to scrollbar rail wrappers to ensure proper stacking order.

<!-- Generated by sourcery-ai[bot]: end summary -->