### PR TITLE
Add Streaming Switch Button for Additional Options

### DIFF
--- a/webapp/src/components/MediaSource.vue
+++ b/webapp/src/components/MediaSource.vue
@@ -173,7 +173,7 @@ export default {
 			const autoplayParam = autoplay ? 'autoplay=1&' : ''
 			// Construct the mute parameter based on the input
 			const muteParam = mute ? 'mute=1' : 'mute=0';
-			const domain = this.$parent.noCookies ? 'www.youtube-nocookie.com' : 'www.youtube.com';
+			const domain = this.getYouTubeDomain();
 			// Return the complete YouTube URL with the provided video ID, autoplay, and mute parameters
 			return `https://${domain}/embed/${ytid}?${autoplayParam}?enablejsapi=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${ytid}&${muteParam}`;
 		},
@@ -181,8 +181,11 @@ export default {
 		getLanguageIframeUrl (languageUrl) {
 			// Checks if the languageUrl is not provided the retun null
 			if (!languageUrl) return null;
-			const domain = this.$parent.noCookies ? 'www.youtube-nocookie.com' : 'www.youtube.com';
+			const domain = this.getYouTubeDomain();
 			return `https://${domain}/embed/${languageUrl}?enablejsapi=1&autoplay=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${languageUrl}`;
+		},
+		getYouTubeDomain() {
+			return this.$parent.$parent.enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
 		}
 	}
 }

--- a/webapp/src/components/MediaSource.vue
+++ b/webapp/src/components/MediaSource.vue
@@ -172,15 +172,17 @@ export default {
 			// Construct the autoplay parameter based on the input
 			const autoplayParam = autoplay ? 'autoplay=1&' : ''
 			// Construct the mute parameter based on the input
-			const muteParam = mute ? 'mute=1' : 'mute=0'
+			const muteParam = mute ? 'mute=1' : 'mute=0';
+			const domain = this.$parent.noCookies ? 'www.youtube-nocookie.com' : 'www.youtube.com';
 			// Return the complete YouTube URL with the provided video ID, autoplay, and mute parameters
-			return `https://www.youtube-nocookie.com/embed/${ytid}?${autoplayParam}?enablejsapi=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${ytid}&${muteParam}`
+			return `https://${domain}/embed/${ytid}?${autoplayParam}?enablejsapi=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${ytid}&${muteParam}`;
 		},
 		// Added method to get the language iframe URL
 		getLanguageIframeUrl (languageUrl) {
 			// Checks if the languageUrl is not provided the retun null
 			if (!languageUrl) return null;
-			return `https://www.youtube-nocookie.com/embed/${languageUrl}?enablejsapi=1&autoplay=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${languageUrl}`
+			const domain = this.$parent.noCookies ? 'www.youtube-nocookie.com' : 'www.youtube.com';
+			return `https://${domain}/embed/${languageUrl}?enablejsapi=1&autoplay=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${languageUrl}`;
 		}
 	}
 }

--- a/webapp/src/components/MediaSource.vue
+++ b/webapp/src/components/MediaSource.vue
@@ -114,7 +114,10 @@ export default {
 						break
 					}
 					case 'livestream.youtube': {
-						iframeUrl = this.getYoutubeUrl(this.module.config.ytid, this.autoplay, mute)
+						iframeUrl = this.getYoutubeUrl(this.module.config.ytid, this.autoplay, mute, this.module.config.hideControls,
+							this.module.config.noRelated, this.module.config.autoStart, this.module.config.showinfo, this.module.config.disableKb,
+							this.module.config.loop, this.module.config.modestBranding, this.module.config.enablePrivacyEnhancedMode
+						)
 						break
 					}
 				}
@@ -168,24 +171,27 @@ export default {
 			// Set the language iframe URL when language changes
 			this.languageIframeUrl = this.getLanguageIframeUrl(languageUrl)
 		},
-		getYoutubeUrl (ytid, autoplay, mute) {
+		getYoutubeUrl(ytid, autoplay, mute, hideControls, noRelated, autoStart, showinfo, disableKb, loop, modestBranding, enablePrivacyEnhancedMode) {
 			// Construct the autoplay parameter based on the input
-			const autoplayParam = autoplay ? 'autoplay=1&' : ''
-			// Construct the mute parameter based on the input
+			const autoplayParam = autoplay ? 'autoplay=1&' : '';
 			const muteParam = mute ? 'mute=1' : 'mute=0';
-			const domain = this.getYouTubeDomain();
+			const hideControlsParam = hideControls ? 'controls=0' : 'controls=1';
+			const noRelatedParam = noRelated ? 'rel=0' : 'rel=1';
+			const autoStartParam = autoStart ? 'start=1' : 'start=0';
+			const showinfoParam = showinfo ? 'showinfo=0' : 'showinfo=1';
+			const disableKbParam = disableKb ? 'disablekb=1' : 'disablekb=0';
+			const loopParam = loop ? 'loop=1' : 'loop=0';
+			const modestBrandingParam = modestBranding ? 'modestbranding=1' : 'modestbranding=0';
+			const domain = enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
 			// Return the complete YouTube URL with the provided video ID, autoplay, and mute parameters
-			return `https://${domain}/embed/${ytid}?${autoplayParam}?enablejsapi=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${ytid}&${muteParam}`;
+			return `https://${domain}/embed/${ytid}?${autoplayParam}?${modestBrandingParam}&${loop}${autoStartParam}&${hideControlsParam}&${disableKb}&${noRelatedParam}&${showinfoParam}&playlist=${ytid}&${muteParam}`;
 		},
 		// Added method to get the language iframe URL
-		getLanguageIframeUrl (languageUrl) {
+		getLanguageIframeUrl(languageUrl, enablePrivacyEnhancedMode) {
 			// Checks if the languageUrl is not provided the retun null
 			if (!languageUrl) return null;
-			const domain = this.getYouTubeDomain();
+			const domain = enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
 			return `https://${domain}/embed/${languageUrl}?enablejsapi=1&autoplay=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${languageUrl}`;
-		},
-		getYouTubeDomain() {
-			return this.$parent.$parent.enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
 		}
 	}
 }

--- a/webapp/src/components/MediaSource.vue
+++ b/webapp/src/components/MediaSource.vue
@@ -172,26 +172,40 @@ export default {
 			this.languageIframeUrl = this.getLanguageIframeUrl(languageUrl)
 		},
 		getYoutubeUrl(ytid, autoplay, mute, hideControls, noRelated, autoStart, showinfo, disableKb, loop, modestBranding, enablePrivacyEnhancedMode) {
-			// Construct the autoplay parameter based on the input
-			const autoplayParam = autoplay ? 'autoplay=1&' : '';
-			const muteParam = mute ? 'mute=1' : 'mute=0';
-			const hideControlsParam = hideControls ? 'controls=0' : 'controls=1';
-			const noRelatedParam = noRelated ? 'rel=0' : 'rel=1';
-			const autoStartParam = autoStart ? 'start=1' : 'start=0';
-			const showinfoParam = showinfo ? 'showinfo=0' : 'showinfo=1';
-			const disableKbParam = disableKb ? 'disablekb=1' : 'disablekb=0';
-			const loopParam = loop ? 'loop=1' : 'loop=0';
-			const modestBrandingParam = modestBranding ? 'modestbranding=1' : 'modestbranding=0';
+			const params = new URLSearchParams({
+				autoplay: autoplay ? '1' : '0',
+				mute: mute ? '1' : '0',
+				controls: hideControls ? '0' : '1',
+				rel: noRelated ? '0' : '1',
+				start: autoStart ? '1' : '0',
+				showinfo: showinfo ? '0' : '1',
+				disablekb: disableKb ? '1' : '0',
+				loop: loop ? '1' : '0',
+				modestbranding: modestBranding ? '1' : '0',
+				playlist: ytid,
+			});
+
 			const domain = enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
-			// Return the complete YouTube URL with the provided video ID, autoplay, and mute parameters
-			return `https://${domain}/embed/${ytid}?${autoplayParam}?${modestBrandingParam}&${loop}${autoStartParam}&${hideControlsParam}&${disableKb}&${noRelatedParam}&${showinfoParam}&playlist=${ytid}&${muteParam}`;
+			return `https://${domain}/embed/${ytid}?${params}`;
 		},
 		// Added method to get the language iframe URL
 		getLanguageIframeUrl(languageUrl, enablePrivacyEnhancedMode) {
 			// Checks if the languageUrl is not provided the retun null
 			if (!languageUrl) return null;
+			const params = new URLSearchParams({
+				enablejsapi: '1',
+				autoplay: '1',
+				modestbranding: '1',
+				loop: '1',
+				controls: '0',
+				disablekb: '1',
+				rel: '0',
+				showinfo: '0',
+				playlist: languageUrl,
+			});
+
 			const domain = enablePrivacyEnhancedMode ? 'www.youtube-nocookie.com' : 'www.youtube.com';
-			return `https://${domain}/embed/${languageUrl}?enablejsapi=1&autoplay=1&modestbranding=1&loop=1&controls=0&disablekb=1&rel=0&showinfo=0&playlist=${languageUrl}`;
+			return `https://${domain}/embed/${languageUrl}?${params}`;
 		}
 	}
 }

--- a/webapp/src/views/admin/rooms/types-edit/stage.vue
+++ b/webapp/src/views/admin/rooms/types-edit/stage.vue
@@ -24,7 +24,14 @@
 		bunt-button(@click="addLanguageUrl") + Add Language and Youtube ID
 		// Switch button for no-cookies domain
 		.bunt-switch-container
-			bunt-switch(name="enable-privacy-enhanced-mode", v-model="enablePrivacyEnhancedMode", label="Enable No-Cookies")
+			bunt-switch(name="enablePrivacyEnhancedMode", v-model="enablePrivacyEnhancedMode", label="Enable No-Cookies")
+			bunt-switch(name="loop", v-model="loop", label="Loop")
+			bunt-switch(name="autoStart", v-model="autoStart", label=" Enable Autostart")
+			bunt-switch(name="modestBranding", v-model="modestBranding", label=" Enable Modest Branding")
+			bunt-switch(name="hideControls", v-model="hideControls", label="Enable Hide Controls")
+			bunt-switch(name="noRelated", v-model="noRelated", label=" Enable No Related info")
+			bunt-switch(name="disableKb", v-model="disableKb", label="Enable Keyboard Controls")
+			bunt-switch(name="showInfo", v-model="showInfo", label="Enable No Show Info")
 	bunt-input(v-else-if="modules['livestream.iframe']", name="iframe-player", v-model="modules['livestream.iframe'].config.url", label="Iframe player url", hint="iframe player should be autoplaying and support resizing to small sizes for background playing")
 	sidebar-addons(v-bind="$props")
 </template>
@@ -54,8 +61,7 @@ export default {
 			ISO_LANGUAGE_OPTIONS: this.getLanguageOptions(),
 			b_streamSource: null,
 			// Initial empty array for languages and URLs
-			b_languageUrls: [],
-			enablePrivacyEnhancedMode: false
+			b_languageUrls: []
 		}
 	},
 	validations: {
@@ -78,7 +84,104 @@ export default {
 				this.b_streamSource = value
 				STREAM_SOURCE_OPTIONS.map(option => option.module).forEach(module => this.removeModule(module))
 				this.addModule(STREAM_SOURCE_OPTIONS.find(option => option.id === value).module)
+			}
+		},
+		enablePrivacyEnhancedMode: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.enablePrivacyEnhancedMode
 			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'enablePrivacyEnhancedMode', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'enablePrivacyEnhancedMode')
+				}
+			}
+		},
+		loop: {
+			get () {
+
+				return !!this.modules['livestream.youtube'].config.loop
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'loop', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'loop')
+				}
+			}
+		},
+		autoStart: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.autoStart
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'autoStart', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'autoStart')
+				}
+			}
+		},
+		modestBranding: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.modestBranding
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'modestBranding', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'modestBranding')
+				}
+			}
+		},
+		hideControls: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.hideControls
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'hideControls', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'hideControls')
+				}
+			}
+		},
+		noRelated: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.noRelated
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'noRelated', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'noRelated')
+				}
+			}
+		},
+		disableKb: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.disableKb
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'disableKb', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'disableKb')
+				}
+			}
+		},
+		showInfo: {
+			get () {
+				return !!this.modules['livestream.youtube'].config.showInfo
+			},
+			set (value) {
+				if (value) {
+					this.$set(this.modules['livestream.youtube'].config, 'showInfo', true)
+				} else {
+					this.$delete(this.modules['livestream.youtube'].config, 'showInfo')
+				}
+			}
 		}
 	},
 	created () {

--- a/webapp/src/views/admin/rooms/types-edit/stage.vue
+++ b/webapp/src/views/admin/rooms/types-edit/stage.vue
@@ -22,6 +22,9 @@
 			bunt-input(name="youtube_id" v-model="entry.youtube_id" label="YouTube Video ID")
 			bunt-icon-button(@click="deleteLanguageUrl(index)") delete-outline
 		bunt-button(@click="addLanguageUrl") + Add Language and Youtube ID
+		// Switch button for no-cookies domain
+		.bunt-switch-container
+			bunt-switch(name="no-cookies", v-model="noCookies", label="Enable No-Cookies")
 	bunt-input(v-else-if="modules['livestream.iframe']", name="iframe-player", v-model="modules['livestream.iframe'].config.url", label="Iframe player url", hint="iframe player should be autoplaying and support resizing to small sizes for background playing")
 	sidebar-addons(v-bind="$props")
 </template>
@@ -51,7 +54,8 @@ export default {
 			ISO_LANGUAGE_OPTIONS: this.getLanguageOptions(),
 			b_streamSource: null,
 			// Initial empty array for languages and URLs
-			b_languageUrls: []
+			b_languageUrls: [],
+			noCookies: false
 		}
 	},
 	validations: {
@@ -119,4 +123,6 @@ export default {
 }
 </script>
 <style lang="stylus">
+.bunt-switch-container
+	margin-top: 16px
 </style>

--- a/webapp/src/views/admin/rooms/types-edit/stage.vue
+++ b/webapp/src/views/admin/rooms/types-edit/stage.vue
@@ -24,7 +24,7 @@
 		bunt-button(@click="addLanguageUrl") + Add Language and Youtube ID
 		// Switch button for no-cookies domain
 		.bunt-switch-container
-			bunt-switch(name="no-cookies", v-model="noCookies", label="Enable No-Cookies")
+			bunt-switch(name="enable-privacy-enhanced-mode", v-model="enablePrivacyEnhancedMode", label="Enable No-Cookies")
 	bunt-input(v-else-if="modules['livestream.iframe']", name="iframe-player", v-model="modules['livestream.iframe'].config.url", label="Iframe player url", hint="iframe player should be autoplaying and support resizing to small sizes for background playing")
 	sidebar-addons(v-bind="$props")
 </template>
@@ -55,7 +55,7 @@ export default {
 			b_streamSource: null,
 			// Initial empty array for languages and URLs
 			b_languageUrls: [],
-			noCookies: false
+			enablePrivacyEnhancedMode: false
 		}
 	},
 	validations: {


### PR DESCRIPTION
This PR closes/references issue:  (https://github.com/fossasia/eventyay-video/issues/170)
This update introduces a switch button to toggle between standard and no-cookies YouTube URLs within the app.
![Screenshot from 2024-08-01 16-06-17](https://github.com/user-attachments/assets/d965776e-d27d-47cd-9664-846a30bf2454)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a switch button in the admin room types edit view to toggle between standard and no-cookies YouTube URLs. The YouTube URL construction logic has been updated to respect the state of this switch.

- **New Features**:
    - Introduced a switch button to toggle between standard and no-cookies YouTube URLs in the admin room types edit view.
- **Enhancements**:
    - Updated the YouTube URL construction logic to dynamically switch between 'youtube.com' and 'youtube-nocookie.com' based on the new switch button state.

<!-- Generated by sourcery-ai[bot]: end summary -->