### PR TITLE
Show filter and stars on schedule page

### DIFF
--- a/webapp/src/store/schedule.js
+++ b/webapp/src/store/schedule.js
@@ -52,9 +52,9 @@ export default {
 			const sessions = []
 			const favArr = getters.favs || []
 			for (const session of state.schedule.talks) {
-				if (state.filter?.type === 1 && !favArr?.includes(session.code?.toString())) {
+				if (state.filter?.type === 'fav' && !favArr?.includes(session.code?.toString())) {
 					continue
-				} else if (state.filter?.type === 2) {
+				} else if (state.filter?.type === 'track') {
 					const { tracks } = state.filter
 					if (tracks?.length && !tracks.includes(String(session.track))) {
 						continue

--- a/webapp/src/store/schedule.js
+++ b/webapp/src/store/schedule.js
@@ -7,6 +7,7 @@ export default {
 	state: {
 		schedule: null,
 		errorLoading: null,
+		filter: {},
 		now: moment()
 	},
 	getters: {
@@ -49,7 +50,16 @@ export default {
 		sessions (state, getters, rootState) {
 			if (!state.schedule) return
 			const sessions = []
+			const favArr = getters.favs || []
 			for (const session of state.schedule.talks) {
+				if (state.filter?.type === 1 && !favArr?.includes(session.code?.toString())) {
+					continue
+				} else if (state.filter?.type === 2) {
+					const { tracks } = state.filter
+					if (tracks?.length && !tracks.includes(String(session.track))) {
+						continue
+					}
+				}
 				sessions.push({
 					id: session.code ? session.code.toString() : null,
 					title: session.title,
@@ -149,6 +159,9 @@ export default {
 				}
 			})
 			// TODO error handling
+		},
+		filter ({ state }, filter) {
+			state.filter = filter
 		}
 	}
 }

--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -4,6 +4,14 @@
 		//- .timezone-control
 		//- 	p timezone:
 		//- 	timezone-changer
+		div.filter-actions
+			bunt-button.bunt-ripple-ink(@click="open=true",
+				icon="filter-outline"
+				:class="{active: filter.type == 2}" ) {{ $t('Filter') }}
+			bunt-button.bunt-ripple-ink(v-if="favs",
+				icon="star"
+				@click="toggleFavFilter"
+				:class="{active: filter.type == 1}") {{favs.length}}
 		bunt-tabs.days(v-if="days && days.length > 1", :active-tab="currentDay.toISOString()", ref="tabs", v-scrollbar.x="")
 			bunt-tab(v-for="day in days", :id="day.toISOString()", :header="moment(day).format('dddd DD. MMMM')", @selected="changeDay(day)")
 		.scroll-parent(ref="scrollParent", v-scrollbar.x.y="")
@@ -33,6 +41,12 @@
 		.mdi.mdi-alert-octagon
 		h1 {{ $t('schedule/index:scheduleLoadingError') }}
 	bunt-progress-circular(v-else, size="huge", :page="true")
+	prompt.c-filter-prompt(v-if="open", @close="open=false", name="filter-prompt")
+		.prompt-content
+			h1 {{ $t('Tracks')}}
+			template(v-for="track in schedule.tracks")
+				div.item(v-if="track")
+					bunt-checkbox(v-model="tracksFilter[track.id]",name="track_room_views") {{track.name.de}}
 </template>
 <script>
 import { mapState, mapGetters } from 'vuex'
@@ -40,20 +54,33 @@ import { LinearSchedule, GridSchedule} from '@pretalx/schedule'
 import moment from 'lib/timetravelMoment'
 import TimezoneChanger from 'components/TimezoneChanger'
 import scheduleProvidesMixin from 'components/mixins/schedule-provides'
+import Prompt from 'components/Prompt'
 
 export default {
-	components: { LinearSchedule, GridSchedule, TimezoneChanger },
+	components: { LinearSchedule, GridSchedule, TimezoneChanger, Prompt },
 	mixins: [scheduleProvidesMixin],
 	data () {
 		return {
+			tracksFilter: {},
+			open: false,
 			moment,
 			currentDay: moment().startOf('day')
 		}
 	},
 	computed: {
 		...mapState(['now']),
-		...mapState('schedule', ['schedule', 'errorLoading']),
+		...mapState('schedule', ['schedule', 'errorLoading', 'filter']),
 		...mapGetters('schedule', ['days', 'rooms', 'sessions', 'favs']),
+	},
+	watch: {
+		tracksFilter: {
+			handler: function (newValue) {
+				if (!this.open) return
+				const arr = Object.keys(newValue).filter(key => newValue[key])
+				this.$store.dispatch('schedule/filter', {type: 2, tracks: arr})
+			},
+			deep: true
+		}
 	},
 	methods: {
 		changeDay (day) {
@@ -65,6 +92,14 @@ export default {
 			const tabEl = this.$refs.tabs.$refs.tabElements.find(el => el.id === day.toISOString())
 			// TODO smooth scroll, seems to not work with chrome {behavior: 'smooth', block: 'center', inline: 'center'}
 			tabEl?.$el.scrollIntoView()
+		},
+		toggleFavFilter () {
+			this.tracksFilter = {}
+			if (this.filter.type === 1) {
+				this.$store.dispatch('schedule/filter', {})
+			} else {
+				this.$store.dispatch('schedule/filter', {type: 1})
+			}
 		}
 	}
 }
@@ -110,4 +145,21 @@ export default {
 	.scroll-parent
 		.bunt-scrollbar-rail-wrapper-x, .bunt-scrollbar-rail-wrapper-y
 			z-index: 30
+	.c-filter-prompt
+		.bunt-scrollbar
+			border-radius: 30px
+		.prompt-content
+			padding: 16px
+			display: flex
+			flex-direction: column
+			.item
+				margin: 4px 0px
+	.bunt-ripple-ink
+		width: fit-content
+		padding: 0px 16px
+		border-radius: 2px
+		height: 32px
+		margin: 16px 8px
+		&.active
+			border: 2px solid #f9a557
 </style>

--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -46,7 +46,7 @@
 			h1 {{ $t('Tracks')}}
 			template(v-for="track in schedule.tracks")
 				div.item(v-if="track")
-					bunt-checkbox(v-model="tracksFilter[track.id]",name="track_room_views") {{track.name.de}}
+					bunt-checkbox(v-model="tracksFilter[track.id]",name="track_room_views") {{track.name}}
 </template>
 <script>
 import { mapState, mapGetters } from 'vuex'

--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -7,11 +7,11 @@
 		div.filter-actions
 			bunt-button.bunt-ripple-ink(@click="open=true",
 				icon="filter-outline"
-				:class="{active: filter.type == 2}" ) {{ $t('Filter') }}
+				:class="{active: filter.type === 'track'}" ) {{ $t('Filter') }}
 			bunt-button.bunt-ripple-ink(v-if="favs",
 				icon="star"
 				@click="toggleFavFilter"
-				:class="{active: filter.type == 1}") {{favs.length}}
+				:class="{active: filter.type === 'fav'}") {{favs.length}}
 		bunt-tabs.days(v-if="days && days.length > 1", :active-tab="currentDay.toISOString()", ref="tabs", v-scrollbar.x="")
 			bunt-tab(v-for="day in days", :id="day.toISOString()", :header="moment(day).format('dddd DD. MMMM')", @selected="changeDay(day)")
 		.scroll-parent(ref="scrollParent", v-scrollbar.x.y="")
@@ -77,7 +77,7 @@ export default {
 			handler: function (newValue) {
 				if (!this.open) return
 				const arr = Object.keys(newValue).filter(key => newValue[key])
-				this.$store.dispatch('schedule/filter', {type: 2, tracks: arr})
+				this.$store.dispatch('schedule/filter', {type: 'track', tracks: arr})
 			},
 			deep: true
 		}
@@ -95,10 +95,10 @@ export default {
 		},
 		toggleFavFilter () {
 			this.tracksFilter = {}
-			if (this.filter.type === 1) {
+			if (this.filter.type === 'fav') {
 				this.$store.dispatch('schedule/filter', {})
 			} else {
-				this.$store.dispatch('schedule/filter', {type: 1})
+				this.$store.dispatch('schedule/filter', {type: 'fav'})
 			}
 		}
 	}


### PR DESCRIPTION
Implement filter and get list stared session

![image](https://github.com/user-attachments/assets/6fa5003d-5787-4ae6-bc91-f2fd88d5e2f4)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement filter functionality on the schedule page, including the ability to filter sessions by track or favorites. Add UI elements to support these features, such as buttons for toggling the filter prompt and filtering by favorites.

New Features:
- Add filter functionality to the schedule page, allowing users to filter sessions by track or favorites.

Enhancements:
- Display a button to toggle the filter prompt and a button to filter by favorite sessions on the schedule page.

<!-- Generated by sourcery-ai[bot]: end summary -->