### PR TITLE
Remove autoplay switch button from room settings UI

### DIFF
--- a/webapp/src/components/MediaSource.vue
+++ b/webapp/src/components/MediaSource.vue
@@ -115,7 +115,7 @@ export default {
 					}
 					case 'livestream.youtube': {
 						iframeUrl = this.getYoutubeUrl(this.module.config.ytid, this.autoplay, mute, this.module.config.hideControls,
-							this.module.config.noRelated, this.module.config.autoStart, this.module.config.showinfo, this.module.config.disableKb,
+							this.module.config.noRelated, this.module.config.showinfo, this.module.config.disableKb,
 							this.module.config.loop, this.module.config.modestBranding, this.module.config.enablePrivacyEnhancedMode
 						)
 						break
@@ -171,13 +171,12 @@ export default {
 			// Set the language iframe URL when language changes
 			this.languageIframeUrl = this.getLanguageIframeUrl(languageUrl)
 		},
-		getYoutubeUrl(ytid, autoplay, mute, hideControls, noRelated, autoStart, showinfo, disableKb, loop, modestBranding, enablePrivacyEnhancedMode) {
+		getYoutubeUrl(ytid, autoplay, mute, hideControls, noRelated, showinfo, disableKb, loop, modestBranding, enablePrivacyEnhancedMode) {
 			const params = new URLSearchParams({
 				autoplay: autoplay ? '1' : '0',
 				mute: mute ? '1' : '0',
 				controls: hideControls ? '0' : '1',
 				rel: noRelated ? '0' : '1',
-				start: autoStart ? '1' : '0',
 				showinfo: showinfo ? '0' : '1',
 				disablekb: disableKb ? '1' : '0',
 				loop: loop ? '1' : '0',

--- a/webapp/src/views/admin/rooms/types-edit/stage.vue
+++ b/webapp/src/views/admin/rooms/types-edit/stage.vue
@@ -26,7 +26,6 @@
 		.bunt-switch-container
 			bunt-switch(name="enablePrivacyEnhancedMode", v-model="enablePrivacyEnhancedMode", label="Enable No-Cookies")
 			bunt-switch(name="loop", v-model="loop", label="Loop")
-			bunt-switch(name="autoStart", v-model="autoStart", label=" Enable Autostart")
 			bunt-switch(name="modestBranding", v-model="modestBranding", label=" Enable Modest Branding")
 			bunt-switch(name="hideControls", v-model="hideControls", label="Enable Hide Controls")
 			bunt-switch(name="noRelated", v-model="noRelated", label=" Enable No Related info")
@@ -108,18 +107,6 @@ export default {
 					this.$set(this.modules['livestream.youtube'].config, 'loop', true)
 				} else {
 					this.$delete(this.modules['livestream.youtube'].config, 'loop')
-				}
-			}
-		},
-		autoStart: {
-			get () {
-				return !!this.modules['livestream.youtube'].config.autoStart
-			},
-			set (value) {
-				if (value) {
-					this.$set(this.modules['livestream.youtube'].config, 'autoStart', true)
-				} else {
-					this.$delete(this.modules['livestream.youtube'].config, 'autoStart')
 				}
 			}
 		},


### PR DESCRIPTION
This PR addresses the issue discussed here: [https://github.com/fossasia/eventyay-video/pull/188#issuecomment-2267838309](https://github.com/fossasia/eventyay-video/pull/188#issuecomment-2267838309)

It removes the autoplay switch button from the room settings. Livestream videos will autoplay by default, and this setting can be adjusted in the user profile settings. By eliminating the redundant autoplay switch, this update simplifies the user interface and reduces confusion.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the autoplay switch button from the room settings UI, making livestream videos autoplay by default and allowing this setting to be adjusted in the user profile settings.

Enhancements:
- Remove the autoplay switch button from the room settings UI to simplify the interface and reduce user confusion.

<!-- Generated by sourcery-ai[bot]: end summary -->