### PR TITLE
Rename dropdown item from Default to Original

### DIFF
--- a/webapp/src/views/rooms/item.vue
+++ b/webapp/src/views/rooms/item.vue
@@ -102,8 +102,8 @@ export default {
 			if (this.modules['livestream.youtube'] && this.modules['livestream.youtube'].config.languageUrls) {
 				this.languages = this.modules['livestream.youtube'].config.languageUrls;
 			}
-			if (!this.languages.find(lang => lang.language === 'Default')) {
-				this.languages.unshift({language: 'Default', url: ``});
+			if (!this.languages.find(lang => lang.language === 'Original')) {
+				this.languages.unshift({language: 'Original', url: ``});
 			}
 		}
 	}


### PR DESCRIPTION
This PR is to closes: [https://github.com/fossasia/eventyay-video/issues/206](https://github.com/fossasia/eventyay-video/issues/206)

Rename `Default` to `Original` in language dropdown menu
![Peek 2024-08-07 11-05](https://github.com/user-attachments/assets/3948ff91-e80c-4124-860b-d010d2419c53)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Rename 'Default' to 'Original' in the language dropdown menu to enhance user understanding.

Enhancements:
- Rename 'Default' to 'Original' in the language dropdown menu to improve clarity.

<!-- Generated by sourcery-ai[bot]: end summary -->