### PR TITLE
update dependencies to latest stable versions

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,11 +6,11 @@ celery==5.3.*
 channels==4.1.*
 channels_redis==4.2.*
 Django==4.2.*
-django-cors-headers==4.3.*
+django-cors-headers==4.4.*
 django-decorator-include==3.0
 django-extensions==3.2.*
 django-formset-js-improved
-django-multifactor==0.6.2
+django-multifactor==0.7.0
 djangorestframework==3.15.*
 emoji==2.12.*
 icalendar==5.0.*
@@ -18,7 +18,7 @@ lxml==5.2.*
 matplotlib==3.9.*
 numpy==1.26.*
 orjson==3.10.*
-openpyxl~=3.1.2
+openpyxl~=3.1.5
 Pillow==10.3.*
 pandas==2.1.*
 pdf2image==1.17.*
@@ -26,9 +26,9 @@ pdfrw==0.4
 pyjwt==2.8.*
 python-dateutil==2.9.*
 pytz
-redis==5.0.4
+redis==5.0.7
 reportlab==4.2.*
-requests==2.31.*
+requests==2.32.*
 sentry-sdk==1.30.*
 tqdm==4.66.*
 websockets==12.*
@@ -36,15 +36,15 @@ websockets==12.*
 # deploy
 psycopg2==2.9.9
 gunicorn==21.2.0
-uvicorn[standard]==0.26.0
+uvicorn[standard]==0.25.0
 
 # dev
 daphne==4.1.*
-black==23.7
+black==24.1
 isort==5.13.2
-flake8==7.0.0
-pytest==8.2.0
-pytest-django==4.7.0
+flake8==7.1.0
+pytest==8.2.2
+pytest-django==4.8.0
 pytest-asyncio==0.23.7
 pytest-cov==5.0.0
 pytest-rerunfailures==14.0


### PR DESCRIPTION
This PR is updated the dependencies to closes: [ Update to latest Dependencies #143 ](https://github.com/fossasia/eventyay-video/issues/143)

Updated dependencies in `requirements.txt` across production, deployment, and development categories. Some of the dependencies has been updated, here is the PR for reference: [Update the dependencies #101](https://github.com/fossasia/eventyay-video/issues/143)

 Specific version updates include:
- `django-cors-headers==4.3.*` to `4.4.*`
- `django-multifactor==0.6.2` to `0.7.0`
- `openpyxl~=3.1.2` to `3.1.5`
- `redis==5.0.4` to `5.0.7`
- `requests==2.31.*` to `2.32.*`
- `uvicorn[standard]==0.26.0` to `0.25.0`
- `black==23.7` to `24.1`
- `flake8==7.0.0` to `7.1.0`
- `pytest==8.2.0` to `8.2.2`
- `pytest-django==4.7.0` to `4.8.0`

 Testing:
- Rebuilt Docker images with updated dependencies.