### PR TITLE
Add workflow to build docker on PRs to main and devevelopment.

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,17 @@
+name: Docker PR Build
+
+on:
+  pull_request:
+    branches: [development, main]
+
+jobs:
+  build_docker_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: docker build -t eventyay-video:${{ github.sha }} .


### PR DESCRIPTION
Closes https://github.com/fossasia/eventyay-video/issues/159.

This PR adds a workflow that builds docker on each PR. That will allow us to ensure that nothing breaks the build gets merged.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a CI workflow to build Docker images for pull requests targeting the 'main' and 'development' branches to ensure build integrity before merging.

CI:
- Add a GitHub Actions workflow to build Docker images on pull requests to the 'main' and 'development' branches.

<!-- Generated by sourcery-ai[bot]: end summary -->