### PR TITLE
update pytest from 8.2.0 to 8.3.3

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -43,7 +43,7 @@ daphne==4.1.*
 black==23.7
 isort==5.13.2
 flake8==7.0.0
-pytest==8.2.0
+pytest==8.3.3
 pytest-django==4.9.0
 pytest-asyncio==0.23.7
 pytest-cov==5.0.0


### PR DESCRIPTION
Update pytest requirements from 8.2.0 to 8.3.3
This update has been tested locally.