### PR TITLE
Update uvicorn[standard] from 0.30.6 to 0.31.0

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -43,7 +43,7 @@ daphne==4.1.*
 black==23.7
 isort==5.13.2
 flake8==7.0.0
-pytest==8.2.0
+pytest==8.3.3
 pytest-django==4.9.0
 pytest-asyncio==0.23.7
 pytest-cov==5.0.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -36,7 +36,7 @@ websockets==12.*
 # deploy
 psycopg2==2.9.9
 gunicorn==21.2.0
-uvicorn[standard]==0.30.6
+uvicorn[standard]==0.31.0
 
 # dev
 daphne==4.1.*


### PR DESCRIPTION
Update uvicorn [standard] requirement from 0.30.6 to 0.31.0
This update has been tested locally.
