### PR TITLE
update openpyxl from 3.1.2 to 3.1.4

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -18,7 +18,7 @@ lxml==5.2.*
 matplotlib==3.9.*
 numpy==2.1.*
 orjson==3.10.*
-openpyxl~=3.1.2
+openpyxl~=3.1.4
 Pillow==10.3.*
 pandas==2.2.*
 pdf2image==1.17.*


### PR DESCRIPTION
Update `openpyxl` from `3.1.2` to `3.1.4`
This update has been tested locally.