### PR TITLE
create docs deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy Sphinx Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - development  # Adjust this to your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        working-directory: docs
+
+      - name: Build documentation
+        run: make html
+        working-directory: docs  # Adjust to your Sphinx docs directory
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+evideo.eventyay.com


### PR DESCRIPTION
fixes #300 

## Screenshot
![image](https://github.com/user-attachments/assets/183ebb5b-c52b-47d4-91a2-5f8a1fe90841)

## Summary
- create the gh-pages Branch
- added github workflow to build and deploy the documentation automatically to the branch gh-pages
- added CNAME file to the root directory.

## Summary by Sourcery

Set up automatic deployment of Sphinx documentation to GitHub Pages on the `gh-pages` branch from the `development` branch.

CI:
- Add CI workflow to automatically build and deploy documentation to GitHub Pages on push to the `development` branch.

Deployment:
- Deploy documentation to the `gh-pages` branch.