### PR TITLE
Better docker development tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.11-bookworm
+ARG UID=15371
+ARG GID=15371
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash && \
     apt-get install -y --install-suggests \
@@ -23,7 +25,8 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash && \
     mkdir /etc/venueless && \
     mkdir -p /venueless/webapp && \
     mkdir /data && \
-    useradd -ms /bin/bash -d /venueless -u 15371 venueless && \
+    groupadd -g $GID venueless && \
+    useradd -ms /bin/bash -d /venueless -u $UID -g venueless venueless && \
     echo 'venueless ALL=(ALL) NOPASSWD:SETENV: /usr/bin/supervisord' >> /etc/sudoers && \
     mkdir /static
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+
+local:
+	docker buildx build --progress=plain -f Dockerfile --platform=linux/amd64  \
+		--build-arg UID=`id -u` --build-arg GID=`id -g`  \
+		-t eventyay/eventyay-video:local .

--- a/prod/entrypoint.bash
+++ b/prod/entrypoint.bash
@@ -5,6 +5,15 @@ export VENUELESS_DATA_DIR=/data/
 export HOME=/venueless
 export NUM_WORKERS=${VENUELESS_WORKERS:-$((2 * $(nproc --all)))}
 
+GUNICORN_RELOAD="${GUNICORN_RELOAD:-false}"
+GUNICORN_LOGLEVEL="${GUNICORN_LOGLEVEL:-info}"
+
+if [ "$GUNICORN_RELOAD" = "true" ]; then
+    RELOAD_ARGUMENT="--reload"
+else
+    RELOAD_ARGUMENT=""
+fi
+
 if [ ! -d /data/logs ]; then
     mkdir /data/logs;
 fi
@@ -17,13 +26,26 @@ if [ "$1" == "all" ]; then
     exec sudo -E /usr/bin/supervisord -n -c /etc/supervisord.conf
 fi
 
+# for in-docker development, we want logging to be debug, and
+# gunicorn to reload when source files have changed.
+if [ "$1" == "devel" ]; then
+    python3 manage.py migrate --noinput
+    export GUNICORN_LOGLEVEL=debug
+    export GUNICORN_RELOAD=true
+    exec sudo -E /usr/bin/supervisord -n -c /etc/supervisord.conf
+fi
+
 if [ "$1" == "celery" ]; then
     exec celery -A venueless.celery_app worker -l info
 fi
 
 if [ "$1" == "webworker" ]; then
     mkdir -p /tmp/venueless
-    exec gunicorn -k uvicorn.workers.UvicornWorker --bind unix:/tmp/venueless/websocket.sock -w "$NUM_WORKERS" venueless.asgi:application
+    exec gunicorn -k uvicorn.workers.UvicornWorker \
+	    --bind unix:/tmp/venueless/websocket.sock \
+            $RELOAD_ARGUMENT \
+            --log-level="${GUNICORN_LOGLEVEL}" \
+	    -w "$NUM_WORKERS" venueless.asgi:application
 fi
 
 if [ "$1" == "shell" ]; then


### PR DESCRIPTION
* make hard-coded UID/GID in Dockerfile configurable
* add a Makefile to build the local docker image
* Allow pretalx to take argument devel for hot reloading gunicorn

## Summary by Sourcery

Configure UID/GID in Dockerfile, add Makefile for local image building, and allow hot reloading of gunicorn with a `devel` argument.

Enhancements:
- Add a `devel` argument to the entrypoint script to enable hot reloading of gunicorn and set the log level to debug.
- Make the gunicorn logging level and reload behavior configurable via environment variables

Build:
- Add a Makefile to build the local Docker image with configurable UID/GID.
- Parameterize the user ID and group ID in the Dockerfile to allow building images with arbitrary user/group IDs at build time