### PR TITLE
Add .dockerignore for webapp

### DIFF
--- a/webapp/.dockerignore
+++ b/webapp/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/dist


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add .dockerignore file to webapp directory to exclude unnecessary files from Docker build context