### PR TITLE
chore:match eventyay-talk room order in schedule

### DIFF
--- a/server/venueless/core/models/room.py
+++ b/server/venueless/core/models/room.py
@@ -150,7 +150,7 @@ class Room(VersionedModel):
     name = models.CharField(max_length=300)
     description = models.TextField(null=True, blank=True)
     picture = models.FileField(null=True, blank=True)
-    sorting_priority = models.IntegerField(default=0)
+    sorting_priority = models.PositiveIntegerField(null=True, blank=True)
     import_id = models.CharField(max_length=100, null=True, blank=True)
     pretalx_id = models.IntegerField(default=0)
     schedule_data = JSONField(null=True, blank=True)
@@ -159,7 +159,7 @@ class Room(VersionedModel):
     objects = RoomQuerySet.as_manager()
 
     class Meta:
-        ordering = ("sorting_priority", "name")
+        ordering = ("sorting_priority",)
 
 
 class Reaction(models.Model):


### PR DESCRIPTION
Fixes #383

## Summary by Sourcery

Simplify room reordering logic, ensure sorting priorities reflect provided order, and refine the model's sorting_priority definition and default ordering.

Enhancements:
- Implement mapping of room IDs to positions for efficient reordering and bulk update only changed rooms
- Change sorting_priority field to PositiveIntegerField with nullable values and adjust model Meta ordering to only sort by sorting_priority