### PR TITLE
Fix: Schedule rooms order doesn't match Talk site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ htmlcov/
 *~
 .ropeproject
 __pycache__/
+.cache
+.npm
 .idea
 .secret
 atlassian-ide-plugin.xml
@@ -23,4 +25,4 @@ data/media
 static.dist/
 node_modules
 docker-compose.override.yml
-
+.bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN cd /venueless/webapp && \
 
 COPY server /venueless/server
 WORKDIR /venueless/server
-RUN python manage.py collectstatic
+RUN python manage.py collectstatic --no-input
 
 ARG COMMIT=""
 LABEL commit=${COMMIT}

--- a/webapp/src/store/schedule.js
+++ b/webapp/src/store/schedule.js
@@ -23,7 +23,8 @@ export default {
 			if (!rootState.world.pretalx.domain.endsWith('/')) {
 				rootState.world.pretalx.domain += '/'
 			}
-			return rootState.world.pretalx.domain + rootState.world.pretalx.event + '/schedule/widget/v2.json'
+			const url = new URL(`${rootState.world.pretalx.event}/schedule/widgets/schedule.json`, rootState.world.pretalx.domain)
+			return url.toString()
 		},
 		pretalxApiBaseUrl(state, getters, rootState) {
 			if (!rootState.world.pretalx?.domain || !rootState.world.pretalx?.event) return

--- a/webapp/src/store/schedule.js
+++ b/webapp/src/store/schedule.js
@@ -16,14 +16,18 @@ export default {
 			return rootState.user?.client_state?.schedule?.favs || []
 		},
 		pretalxScheduleUrl(state, getters, rootState) {
-			if (rootState.world.pretalx?.url) {
-				return rootState.world.pretalx.url
+			if (!rootState.world.pretalx) {
+				return ''
 			}
-			if (!rootState.world.pretalx?.domain || !rootState.world.pretalx?.event) return
-			if (!rootState.world.pretalx.domain.endsWith('/')) {
-				rootState.world.pretalx.domain += '/'
+			const pretalx = rootState.world.pretalx
+			if (pretalx.url) {
+				return pretalx.url
 			}
-			const url = new URL(`${rootState.world.pretalx.event}/schedule/widgets/schedule.json`, rootState.world.pretalx.domain)
+			if (!pretalx.domain || !pretalx.event) return ''
+			if (!pretalx.domain.endsWith('/')) {
+				pretalx.domain += '/'
+			}
+			const url = new URL(`${pretalx.event}/schedule/widgets/schedule.json`, pretalx.domain)
 			return url.toString()
 		},
 		pretalxApiBaseUrl(state, getters, rootState) {

--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -193,7 +193,8 @@ export default {
 			return sessions
 		},
 		rooms() {
-			return _.uniqBy(this.sessions, 'room.id').map(s => s.room)
+		  const occupiedRoomIds = this.sessions.map(s => s.room.id)
+			return this.schedule.rooms.filter(r => occupiedRoomIds.includes(r.id))
 		},
 		filter() {
 			const filter = this.defaultFilter


### PR DESCRIPTION
Fixes #383 

## Summary by Sourcery

Fix schedule data loading and room ordering to align with the Talk site and ensure automated static file collection

Enhancements:
- Use URL API to construct Pretalx schedule endpoint and update to the correct widget path
- Preserve original room ordering by filtering the fetched room list instead of deriving order from sessions

Build:
- Add --no-input flag to manage.py collectstatic in Dockerfile