### PR TITLE
fix: resolve eslint errors in webapp

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -191,7 +191,7 @@ export default {
 				this.$refs.primaryMediaSource.isPlaying() &&
 				// don't background bbb room when switching to new bbb room
 				!(newRoom?.modules.some(isExclusive) && oldRoom?.modules.some(isExclusive)) &&
-				!newRoomHasMedia 
+				!newRoomHasMedia
 			) {
 				this.backgroundRoom = oldRoom
 			} else if (newRoomHasMedia) {

--- a/webapp/src/views/schedule/index.vue
+++ b/webapp/src/views/schedule/index.vue
@@ -60,7 +60,7 @@
 	bunt-progress-circular(v-else, size="huge", :page="true")
 </template>
 <script>
-import _ from 'lodash'
+// import _ from 'lodash'
 import { mapState, mapGetters } from 'vuex'
 import LinearSchedule from 'views/schedule/schedule-components/LinearSchedule'
 import GridSchedule from 'views/schedule/schedule-components/GridSchedule'
@@ -193,7 +193,7 @@ export default {
 			return sessions
 		},
 		rooms() {
-		  const occupiedRoomIds = this.sessions.map(s => s.room.id)
+			const occupiedRoomIds = this.sessions.map(s => s.room.id)
 			return this.schedule.rooms.filter(r => occupiedRoomIds.includes(r.id))
 		},
 		filter() {

--- a/webapp/src/views/schedule/sessions/index.vue
+++ b/webapp/src/views/schedule/sessions/index.vue
@@ -191,15 +191,11 @@ export default {
 			filter.tracks.data = this.filterItemsByLanguage(this?.schedule?.tracks)
 			return filter
 		},
-		inEventTimezone () {
+		inEventTimezone() {
 			if (!this.schedule?.talks?.length) return false
 			const example = this.schedule.talks[0].start
 			return moment.tz(example, this.userTimezone).format('Z') === moment.tz(example, this.schedule.timezone).format('Z')
 		},
-	},
-	async created () {
-		this.userTimezone = moment.tz.guess()
-		this.currentTimezone = localStorage.getItem(`userTimezone`)
 	},
 	watch: {
 		tracksFilter: {
@@ -210,6 +206,10 @@ export default {
 			},
 			deep: true
 		}
+	},
+	async created() {
+		this.userTimezone = moment.tz.guess()
+		this.currentTimezone = localStorage.getItem('userTimezone')
 	},
 	methods: {
 		changeDay(day) {
@@ -288,8 +288,8 @@ export default {
 		resetOnlyFavs() {
 			this.onlyFavs = false
 		},
-		saveTimezone () {
-			localStorage.setItem(`userTimezone`, this.currentTimezone)
+		saveTimezone() {
+			localStorage.setItem('userTimezone', this.currentTimezone)
 		},
 	}
 }


### PR DESCRIPTION
While following the build instructions in `eventyay-docker`, the following warnings appeared:

```c
WARNING  Compiled with 4 warnings                                                                2:17:57 PM

Module Warning (from ./node_modules/eslint-loader/index.js):

/home/ishan/fossasia/eventyay-dev/eventyay-video/webapp/src/App.vue
  194:21  error  Trailing spaces not allowed  no-trailing-spaces

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.


Module Warning (from ./node_modules/eslint-loader/index.js):

/home/ishan/fossasia/eventyay-dev/eventyay-video/webapp/src/views/schedule/index.vue
   63:8  error  '_' is defined but never used  no-unused-vars
  196:2  error  Mixed spaces and tabs          no-mixed-spaces-and-tabs

✖ 2 problems (2 errors, 0 warnings)


Module Warning (from ./node_modules/eslint-loader/index.js):

/home/ishan/fossasia/eventyay-dev/eventyay-video/webapp/src/views/schedule/sessions/index.vue
  194:18  error    Unexpected space before function parentheses                             space-before-function-paren
  200:15  error    Unexpected space before function parentheses                             space-before-function-paren
  202:47  error    Strings must use singlequote                                             quotes
  204:2   warning  The "watch" property should be above the "created" property on line 200  vue/order-in-components
  291:15  error    Unexpected space before function parentheses                             space-before-function-paren
  292:25  error    Strings must use singlequote                                             quotes
```

This PR resolves these lint errors.

## Summary by Sourcery

Resolve ESLint errors across the webapp by cleaning up imports, standardizing quotes, correcting spacing and indentation, and adjusting component option order

Enhancements:
- Remove unused imports and variables
- Standardize string literals to use single quotes instead of backticks
- Fix spacing issues including trailing spaces, mixed spaces and tabs, and unexpected spaces before function parentheses
- Reorder Vue component options to satisfy vue/order-in-components rule