### PR TITLE
fix: window resize event listener

### DIFF
--- a/webapp/src/components/Chat.vue
+++ b/webapp/src/components/Chat.vue
@@ -107,7 +107,6 @@ export default {
 		},
 		async filteredTimeline() {
 			await this.$nextTick()
-			// TODO scroll to bottom when resizing
 			// restore scrollPosition after load
 			this.refreshScrollbar()
 			this.syncedScroll = true
@@ -117,7 +116,11 @@ export default {
 	created() {
 		this.$store.dispatch('chat/subscribe', {channel: this.module.channel_id, config: this.module.config})
 	},
+	mounted() {
+		window.addEventListener('resize', this.onResize)
+	},
 	beforeDestroy() {
+		window.removeEventListener('resize', this.onResize)
 		this.$store.dispatch('chat/unsubscribe')
 	},
 	methods: {


### PR DESCRIPTION
#445 
This pull request introduces improvements to the `Chat.vue` component by adding proper handling for window resize events. This ensures that the chat interface responds correctly to changes in window size and cleans up event listeners to prevent memory leaks.

Event handling improvements:

* Added a `mounted` lifecycle hook to register a window resize event listener that calls the `onResize` method when the component is mounted.
* Added cleanup in the `beforeDestroy` lifecycle hook to remove the window resize event listener when the component is destroyed.

Minor code cleanup:

* Removed an outdated comment about scrolling to the bottom on resize, as the new event handling addresses this behavior.

## Summary by Sourcery

Handle chat component window resize events and clean up listeners on component lifecycle changes.

Bug Fixes:
- Ensure the chat interface responds correctly to browser window resize events by registering a resize handler on mount.
- Prevent potential memory leaks by removing the window resize event listener when the chat component is destroyed.

Enhancements:
- Remove an outdated comment about resize scrolling behavior from the chat component.